### PR TITLE
family->given for R Core authorship

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
     role=c("aut", "cre")),
     person(family="Paxdiablo", role="cph", comment="Hash
     table implementation in src/pfhash.h"),
-    person(family="R Core Team",
+    person(given="R Core Team",
     email="R-core@r-project.org", role="cph",
     comment="Used/adapted several code snippets from R sources, see src/r-copied.c"))
 Depends:


### PR DESCRIPTION
This is the more typical and correct way to cite this contributor.

c.f.

```r
a = tools::CRAN_authors_db()
sum(grepl("(?i)r core team", a$family))
# [1] 8
sum(grepl("(?i)r core team", a$given))
# [1] 61
```

From `?person`:

> For persons which are not natural persons (e.g., institutions, companies, etc.) it is appropriate to use `given` (but not `family`) for the name, e.g., `person("R Core Team", role = "aut")`.